### PR TITLE
Add support for (remote) pigpio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN addgroup -gid 997 gpio && addgroup -gid 1001 p1mon && adduser --gid 1001 --d
 RUN echo >>/etc/sudoers "p1mon ALL=(ALL) NOPASSWD: ALL" && echo >>/etc/sudoers "www-data ALL=(p1mon) NOPASSWD: /p1mon/scripts/*"
 
 # Install Python packages required
-RUN pip3 install pythoncrc gunicorn certifi cffi chardet colorzero dropbox falcon future gpiozero idna iso8601 paho-mqtt psutil pycparser pycrypto pyserial python-crontab python-dateutil pytz PyYAML requests RPi.GPIO setuptools spidev urllib3 xlsxwriter
+RUN pip3 install pythoncrc gunicorn certifi cffi chardet colorzero dropbox falcon future gpiozero idna iso8601 paho-mqtt pigpio psutil pycparser pycrypto pyserial python-crontab python-dateutil pytz PyYAML requests RPi.GPIO setuptools spidev urllib3 xlsxwriter
 # --no-cache-dir
 
 # Copy original p1mon directory

--- a/addons/entrypoint.sh
+++ b/addons/entrypoint.sh
@@ -43,7 +43,7 @@ if [[ ! -z $SOCAT_CONF ]]; then
 fi
 
 echo "Starting p1mon"
-sudo /p1mon/scripts/p1mon.sh start
+sudo --preserve-env=GPIOZERO_PIN_FACTORY,PIGPIO_ADDR /p1mon/scripts/p1mon.sh start
 
 echo "Setting ramdisk rights"
 sudo chown p1mon:p1mon /p1mon/mnt/ramdisk/*db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,6 @@ services:
       #- DISABLECPUTEMP=true
       #- SOCAT_CONF="pty,link=/dev/ttyUSB1,rawer,group-late=dialout,mode=660 tcp:192.168.1.200:23,retry=forever,interval=30"
       #- PROXYPATH=marcel
+      #- PROXYPATH=marcel
+      #- GPIOZERO_PIN_FACTORY=pigpio
+      #- PIGPIO_ADDR=raspberry.local


### PR DESCRIPTION
Selecting pigpio as pinfactory for gpiozero allows using remote gpio, for example on a different raspberry. This is especially usefull when the docker container is running on a host that is not location where you want to use the gpio, for example to measure watermeter pulses.

Adding GPIOZERO_PIN_FACTORY=pigpio and PIGPIO_ADDR=<somehost> to the docker-compose file is sufficient to allow p1monitor to use the gpios of a remote raspberry. The remote raspberry has to run the pigpiod.service, which is available in the pigpio raspbian/debian package.